### PR TITLE
Update to pg_query 0.9.1, adds PostgreSQL 9.5 syntax support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     diff-lcs (1.2.5)
     json (1.8.3)
-    pg_query (0.5.0)
+    pg_query (0.9.1)
       json (~> 1.8)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
@@ -27,4 +27,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.10.3
+   1.11.2

--- a/lib/sqlint/linter.rb
+++ b/lib/sqlint/linter.rb
@@ -56,7 +56,9 @@ module SQLint
     end
 
     def clean_message(message)
-      message.gsub(/(?<=at or near ")(.*)(?=")/) { |match| match[0..49] }
+      message
+      .gsub(/(?<=at or near ")(.*)(?=")/) { |match| match[0..49] }
+      .gsub(/\s+\(scan\.l\:\d+\)/, '')
     end
   end
 end

--- a/sqlint.gemspec
+++ b/sqlint.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = '1.8.23'
   s.summary = 'Simple SQL linter.'
 
-  s.add_runtime_dependency('pg_query', '~> 0.5')
+  s.add_runtime_dependency('pg_query', '~> 0.9.1')
   s.add_development_dependency('rake', '~> 10.1')
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('bundler', '~> 1.3')


### PR DESCRIPTION
First of all, thanks for building this on top of pg_query! :)

I saw you are using an older version of pg_query right now (0.5), and I recently released 0.9.0 - which amongst other improvements is based on PostgreSQL 9.5 - which means `sqlint` will also support UPSERT once you upgrade.

Tests all pass, I had to fix a minor detail with error messages (they are more verbose now), but output should be identical for the end user.