### PR TITLE
Allow substitution tokens in valid SQL.

### DIFF
--- a/lib/sqlint/linter.rb
+++ b/lib/sqlint/linter.rb
@@ -7,7 +7,7 @@ module SQLint
     END_PARSE = ParseState.new(nil, nil)
 
     def initialize(filename, input_stream)
-      @input = input_stream.read
+      @input = input_stream.read.gsub(/(?<!')%s(?!')/, "'%s'")
       @filename = filename
     end
 

--- a/lib/sqlint/version.rb
+++ b/lib/sqlint/version.rb
@@ -1,3 +1,3 @@
 module SQLint
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
 end

--- a/spec/linter_spec.rb
+++ b/spec/linter_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe SQLint::Linter do
       end
     end
 
+    context "with a single substitution token" do
+      let(:input) { "SELECT %s" }
+      it "reports no errors" do
+        expect(results).to be_empty
+      end
+    end
+
     context "with a single invalid keyword" do
       let(:input) { "WIBBLE" }
       it "reports one error" do


### PR DESCRIPTION
This replaces any substitution token (%s) with a quoted version of
that token, to please the parser.

It will not affect a substitution token that is already quoted.